### PR TITLE
feat: ㅍㅔ이지 이동시 맨 위로 자동 스크롤

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -57,6 +57,7 @@ import TossAppLauncher from "./components/Mypage/TossAppLauncher";
 import FAQ from "./pages/FAQ";
 
 import "./App.css";
+import ScrollToTop from "./components/ScrollToTop";
 
 // 메인 앱 컴포넌트 (ServerStatusProvider 내부)
 function AppContent() {
@@ -81,6 +82,7 @@ function AppContent() {
       <div className="App">
         <Header />
         <main>
+          <ScrollToTop />
           <Routes>
             <Route path="/" element={<Landing />} />
             <Route path="/main" element={<Main />} />

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation(); // 현재 페이지 경로를 가져옴
+
+  useEffect(() => {
+    window.scrollTo(0, 0); // 페이지 경로가 변경될 때마다 스크롤을 최상단으로 이동
+  }, [pathname]); // pathname이 변경될 때마다 실행됨
+
+  return null; // 이 컴포넌트는 렌더링할 것이 없으므로 null을 반환
+};
+
+export default ScrollToTop;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 모든 페이지 전환 시 화면을 자동으로 최상단으로 스크롤하는 기능을 추가했습니다. 이제 페이지 이동 후 이전 스크롤 위치가 유지되지 않아, 사용자는 항상 콘텐츠의 시작부터 확인할 수 있습니다.
  * 이 동작은 앱 전역에 일관되게 적용되며, 뒤로 가기 등 내비게이션 시에도 새 화면 진입 시 상단으로 이동해 탐색 경험을 개선합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->