### PR TITLE
fix: 송금 qr 없이도 생성

### DIFF
--- a/src/pages/CreateShow.js
+++ b/src/pages/CreateShow.js
@@ -100,8 +100,6 @@ function CreateShow() {
   const handleQrChange = (e) => {
     const file = e.target.files?.[0] || null;
 
-    if (qrPreview?.startsWith("blob:")) URL.revokeObjectURL(qrPreview);
-
     setQr(file);
     setQrPreview(file ? URL.createObjectURL(file) : null);
   };
@@ -117,8 +115,7 @@ function CreateShow() {
     if (!name) return alert("제목을 입력해 주세요");
     if (!poster || !(poster instanceof File))
       return alert("공연 이미지를 선택해 주세요");
-    if (!qr || !(qr instanceof File))
-      return alert("송금 QR 이미지를 선택해 주세요"); // @RequestPart("qr")
+
     if (!location) return alert("장소를 입력해 주세요");
     if (!runtime || Number(runtime) <= 0)
       return alert("런타임을 입력해 주세요");
@@ -174,7 +171,9 @@ function CreateShow() {
       new Blob([JSON.stringify(requestData)], { type: "application/json" })
     );
     formData.append("poster", poster, "poster.jpg");
-    formData.append("qr", qr, "qr.jpg");
+    if(qr instanceof File){
+    formData.append("qr", qr, "qr.jpg");}
+    else {formData.append("qr", "");}
 
     // Debug info removed: requestData and FormData remain unchanged.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  - QR 이미지 업로드가 필수에서 선택으로 변경되었습니다. 이제 QR 파일 없이도 쇼 생성 폼을 제출할 수 있습니다.
  - QR 없이 제출해도 진행이 중단되지 않으며, 제출 흐름이 보다 유연해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->